### PR TITLE
Replace .Internal with .Class

### DIFF
--- a/avl-auth.cabal
+++ b/avl-auth.cabal
@@ -22,7 +22,7 @@ library
       Crypto.Data.Auth.Tree
       Crypto.Data.Auth.Tree.Proof
       Crypto.Data.Auth.Tree.Cryptonite
-      Crypto.Data.Auth.Tree.Internal
+      Crypto.Data.Auth.Tree.Class
   hs-source-dirs:
       src
   build-depends:

--- a/src/Crypto/Data/Auth/Tree.hs
+++ b/src/Crypto/Data/Auth/Tree.hs
@@ -33,7 +33,7 @@ module Crypto.Data.Auth.Tree
     , balance
     ) where
 
-import           Crypto.Data.Auth.Tree.Internal
+import           Crypto.Data.Auth.Tree.Class
 
 import           Data.Binary (Binary)
 import           Data.ByteArray (ByteArrayAccess)

--- a/src/Crypto/Data/Auth/Tree/Class.hs
+++ b/src/Crypto/Data/Auth/Tree/Class.hs
@@ -1,6 +1,4 @@
-module Crypto.Data.Auth.Tree.Internal where
-
-import           Data.Kind
+module Crypto.Data.Auth.Tree.Class where
 
 import           Prelude
 

--- a/src/Crypto/Data/Auth/Tree/Proof.hs
+++ b/src/Crypto/Data/Auth/Tree/Proof.hs
@@ -1,7 +1,7 @@
 module Crypto.Data.Auth.Tree.Proof where
 
 import           Crypto.Data.Auth.Tree
-import           Crypto.Data.Auth.Tree.Internal
+import           Crypto.Data.Auth.Tree.Class
 import           Data.ByteArray (ByteArrayAccess)
 import           Data.List (intercalate)
 import qualified Data.List as List

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,8 +25,8 @@ import           Test.Tasty.QuickCheck
 
 import           Crypto.Data.Auth.Tree (Tree)
 import qualified Crypto.Data.Auth.Tree as Tree
+import           Crypto.Data.Auth.Tree.Class
 import qualified Crypto.Data.Auth.Tree.Cryptonite as Cryptonite
-import           Crypto.Data.Auth.Tree.Internal
 import qualified Crypto.Data.Auth.Tree.Proof as Tree
 import qualified Crypto.Hash as Cryptonite
 


### PR DESCRIPTION
After #4, the presence of the `.Internal` module was not justified, as all it contains now is the `MerkleHash` typeclass, which I have moved into a more-fitting `.Class` module.