### PR TITLE
Replace xxhash with xxhash-ffi

### DIFF
--- a/avl-auth.cabal
+++ b/avl-auth.cabal
@@ -58,6 +58,7 @@ test-suite test
     , base >=4.7 && <5
     , cryptonite
     , bytestring
+    , hashable
     , memory
     , binary
     , containers
@@ -67,7 +68,7 @@ test-suite test
     , QuickCheck
     , HUnit
     , quickcheck-instances
-    , xxhash
+    , xxhash-ffi
   default-language: Haskell2010
   default-extensions:
       DeriveFoldable

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,6 +10,7 @@ import           Data.ByteArray (ByteArrayAccess(..), convert)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.Either (isLeft, isRight)
+import           Data.Hashable (hash)
 import           Data.Kind
 import           Data.List (sort)
 import           Data.List.NonEmpty (NonEmpty, toList)
@@ -30,13 +31,13 @@ import qualified Crypto.Data.Auth.Tree.Cryptonite as Cryptonite
 import qualified Crypto.Data.Auth.Tree.Proof as Tree
 import qualified Crypto.Hash as Cryptonite
 
-import qualified Data.Digest.XXHash as Mock
+import qualified Data.Digest.XXHash.FFI as Mock
 
 type Key = Word8
 type Val = Word8
 
 type CryptoniteDigest = Cryptonite.Digest Cryptonite.SHA256
-type MockDigest       = Mock.XXHash
+type MockDigest       = Word64
 
 instance MerkleHash (Cryptonite.Digest Cryptonite.SHA256) where
     emptyHash     = Cryptonite.emptyHash
@@ -44,8 +45,8 @@ instance MerkleHash (Cryptonite.Digest Cryptonite.SHA256) where
     concatHashes  = Cryptonite.concatHashes
 
 instance MerkleHash MockDigest where
-    emptyHash          = minBound
-    hashLeaf k v       = Mock.xxHash' (convert k <> convert v)
+    emptyHash          = 0
+    hashLeaf k v       = fromIntegral $ hash $ Mock.XXH3 @ByteString (convert k <> convert v)
     concatHashes d1 d2 = d1 + d2
 
 instance MonadFail Gen where


### PR DESCRIPTION
Tests currently fail on ghc 9.2+.
Switching over from unmaintained `xxhash` makes tests work all the way to ghc 9.10